### PR TITLE
Fix for plugin names with underscores/spaces in names

### DIFF
--- a/Install-A4T-Plugin.ps1
+++ b/Install-A4T-Plugin.ps1
@@ -95,7 +95,7 @@ try
     }
 
     $plugins = ConvertFrom-Json($response)
-    $installedPlugin = $plugins.Where{$_.name -eq $pluginName}
+    $installedPlugin = $plugins.Where{$_.name -eq $pluginName.Replace("_", " ")}
     $pluginIsInstalled = ($installedPlugin.Count -eq 1)
 
     $installedPluginIsDeveloperVersion = $null


### PR DESCRIPTION
The script was failing if the plugin to be installed had a space/underscore in its name. The script would find that it was installed but the request to uninstall would fail.
